### PR TITLE
Modify to use Streams in implementation

### DIFF
--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -2,6 +2,7 @@ package duke;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.stream.IntStream;
 
 /**
  * Contains the tasks list, it has operations to add/delete tasks in the list
@@ -93,12 +94,9 @@ public class TaskList {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < this.tasks.size(); i++) {
-            sb.append("    " + (i + 1) + ". " + this.tasks.get(i));
-            if (i != this.tasks.size() - 1) {
-                sb.append(System.lineSeparator());
-            }
-        }
+        IntStream.range(0, this.tasks.size())
+                .mapToObj(i -> "    " + (i + 1) + ". " + this.tasks.get(i) + System.lineSeparator())
+                .forEach(sb::append);
         return sb.toString();
     }
 
@@ -116,12 +114,10 @@ public class TaskList {
      */
     public String findTasksOnDate(LocalDate date) {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < this.tasks.size(); i++) {
-            if (this.tasks.get(i).isOnDate(date)) {
-                sb.append("    " + (i + 1) + ". " + this.tasks.get(i));
-                sb.append(System.lineSeparator());
-            }
-        }
+        IntStream.range(0, this.tasks.size())
+                .filter(i -> this.tasks.get(i).isOnDate(date))
+                .mapToObj(i -> "    " + (i + 1) + ". " + this.tasks.get(i) + System.lineSeparator())
+                .forEach(sb::append);
         return sb.toString();
     }
 
@@ -133,12 +129,10 @@ public class TaskList {
      */
     public String find(String description) {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < this.tasks.size(); i++) {
-            if (this.tasks.get(i).containsDescription(description)) {
-                sb.append("    " + (i + 1) + ". " + this.tasks.get(i));
-                sb.append(System.lineSeparator());
-            }
-        }
+        IntStream.range(0, this.tasks.size())
+                .filter(i -> this.tasks.get(i).containsDescription(description))
+                .mapToObj(i -> "    " + (i + 1) + ". " + this.tasks.get(i) + System.lineSeparator())
+                .forEach(sb::append);
         return sb.toString();
     }
 


### PR DESCRIPTION
As per the requirement in streams, the TaskList class has been modified to use streams in its implementation. Using streams also gives shorter code and better readability.

Most of the for loops were replaced with IntStream in the TaskList class. It is probably the easiest way to convert a for loop to a stream.

No real impact on performance was observed. The chatbot should still be able to function as per normal.